### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,28 @@
 bazel-*
+
+# KSP2 DLLs
+lib/ksp2/*
+!lib/ksp2/README.txt
+
+# Visual Studio
+.vs/
+.localhistory/
 bin
 obj
+
+# NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# NuGet
+*.nuget.props
+*.nuget.targets
+
+# Python
+__pycache__/
+*.pyc
+.env
+.venv
+
+# MSBuild Binary and Structured Log
+*.binlog

--- a/lib/ksp2
+++ b/lib/ksp2
@@ -1,1 +1,0 @@
-/home/alex/.local/share/Steam/steamapps/common/Kerbal Space Program 2

--- a/lib/ksp2/README.txt
+++ b/lib/ksp2/README.txt
@@ -1,0 +1,1 @@
+Copy KSP_x64_Data from Kerbal Space Program 2 to this directory before compiling


### PR DESCRIPTION
- ignores broken symlink requiring user to manually delete prior to symlinking local ksp2 folder