### PR TITLE
Add basic orbital class (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ Here's an example in Python, with all the currently available telemetry:
 ```
 import krpc
 conn = krpc.connect()
-print(conn.space_center2.horizontal_surface_speed)
-print(conn.space_center2.vertical_surface_speed)
-print(conn.space_center2.terrain_altitude)
-print(conn.space_center2.sealevel_altitude)
+print(conn.space_center2.active_vessel.orbit.eccentricity)
+print(conn.space_center2.active_vessel.orbit.apoapsis)
+print(conn.space_center2.active_vessel.orbit.periapsis)
 ```
 
 ## Development

--- a/service/spacecenter/src/Orbit.cs
+++ b/service/spacecenter/src/Orbit.cs
@@ -1,0 +1,146 @@
+using System;
+using KSP.Sim.impl;
+using KRPC.Service.Attributes;
+using KRPC.Utils;
+
+namespace KRPC2.SpaceCenter
+{
+    /// <summary>
+    /// Describes an orbit. For example, the orbit of a vessel, obtained by calling
+    /// <see cref="Vessel.Orbit"/>.
+    /// </summary>
+    [KRPCClass(Service = "SpaceCenter2")]
+    public class Orbit : Equatable<Orbit>
+    {
+        internal Orbit(VesselComponent vessel)
+        {
+            InternalOrbit = vessel.Orbit;
+        }
+
+        /// <summary>
+        /// Construct a an orbit from a KSP orbit object.
+        /// </summary>
+        public Orbit(PatchedConicsOrbit orbit)
+        {
+            InternalOrbit = orbit;
+        }
+
+        /// <summary>
+        /// Returns true if the objects are equal.
+        /// </summary>
+        public override bool Equals(Orbit other)
+        {
+            return !ReferenceEquals(other, null) && InternalOrbit == other.InternalOrbit;
+        }
+
+        /// <summary>
+        /// Hash code for the object.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return InternalOrbit.GetHashCode();
+        }
+
+        /// <summary>
+        /// The KSP orbit object.
+        /// </summary>
+        public PatchedConicsOrbit InternalOrbit { get; private set; }
+
+        /// <summary>
+        /// Gets the apoapsis of the orbit, in meters, from the center of mass
+        /// of the body being orbited.
+        /// </summary>
+        /// <remarks>
+        /// For the apoapsis altitude reported on the in-game map view,
+        /// use <see cref="ApoapsisAltitude"/>.
+        /// </remarks>
+        [KRPCProperty]
+        public double Apoapsis
+        {
+            get { return InternalOrbit.Apoapsis; }
+        }
+
+        /// <summary>
+        /// The periapsis of the orbit, in meters, from the center of mass
+        /// of the body being orbited.
+        /// </summary>
+        /// <remarks>
+        /// For the periapsis altitude reported on the in-game map view,
+        /// use <see cref="PeriapsisAltitude"/>.
+        /// </remarks>
+        [KRPCProperty]
+        public double Periapsis
+        {
+            get { return InternalOrbit.Periapsis; }
+        }
+
+        /// <summary>
+        /// The apoapsis of the orbit, in meters, above the sea level of the body being orbited.
+        /// </summary>
+        /// <remarks>
+        /// This is equal to <see cref="Apoapsis"/> minus the equatorial radius of the body.
+        /// </remarks>
+        [KRPCProperty]
+        public double ApoapsisAltitude
+        {
+            get { return InternalOrbit.ApoapsisArl; }
+        }
+
+        /// <summary>
+        /// The periapsis of the orbit, in meters, above the sea level of the body being orbited.
+        /// </summary>
+        /// <remarks>
+        /// This is equal to <see cref="Periapsis"/> minus the equatorial radius of the body.
+        /// </remarks>
+        [KRPCProperty]
+        public double PeriapsisAltitude
+        {
+            get { return InternalOrbit.PeriapsisArl; }
+        }
+
+        /// <summary>
+        /// The semi-major axis of the orbit, in meters.
+        /// </summary>
+        [KRPCProperty]
+        public double SemiMajorAxis
+        {
+            get { return 0.5d * (Apoapsis + Periapsis); }
+        }
+
+        /// <summary>
+        /// The semi-minor axis of the orbit, in meters.
+        /// </summary>
+        [KRPCProperty]
+        public double SemiMinorAxis
+        {
+            get
+            {
+                var e = Eccentricity;
+                return SemiMajorAxis * Math.Sqrt(1d - (e * e));
+            }
+        }
+
+        /// <summary>
+        /// Eccentricity of the orbit (from 0 to 1).
+        /// </summary>
+        [KRPCProperty]
+        public double Eccentricity
+        {
+            get { return InternalOrbit.eccentricity; }
+        }
+
+        /// <summary>
+        /// The current radius of the orbit, in meters. This is the distance between the center
+        /// of mass of the object in orbit, and the center of mass of the body around which it
+        /// is orbiting.
+        /// </summary>
+        /// <remarks>
+        /// This value will change over time if the orbit is elliptical.
+        /// </remarks>
+        [KRPCProperty]
+        public double Radius
+        {
+            get { return InternalOrbit.radius; }
+        }
+    }
+}

--- a/service/spacecenter/src/Vessel.cs
+++ b/service/spacecenter/src/Vessel.cs
@@ -13,6 +13,7 @@ namespace KRPC2.SpaceCenter
     [KRPCClass(Service = "SpaceCenter2")]
     public class Vessel : Equatable<Vessel>
     {
+
         /// <summary>
         /// Construct from a VesselComponent.
         /// </summary>
@@ -21,6 +22,7 @@ namespace KRPC2.SpaceCenter
             if (ReferenceEquals(vessel, null))
                 throw new ArgumentNullException(nameof(vessel));
             Id = vessel.GlobalId;
+            InternalVessel = vessel;
         }
 
         /// <summary>
@@ -43,5 +45,19 @@ namespace KRPC2.SpaceCenter
         /// The KSP vessel id.
         /// </summary>
         public IGGuid Id { get; private set; }
+
+        /// <summary>
+        /// The KSP vessel object.
+        /// </summary>
+        public VesselComponent InternalVessel { get; private set; }
+
+        /// <summary>
+        /// The current orbit of the vessel.
+        /// </summary>
+        [KRPCProperty]
+        public Orbit Orbit
+        {
+            get { return new Orbit(InternalVessel); }
+        }
     }
 }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ev
-bazel build //:krpc2
+bazel build --verbose_failures //:krpc2
 rm -rf lib/ksp2/BepInEx/plugins/kRPC2
 rm -f lib/ksp2/BepInEx/config/krpc2.cfg
-cp -r bazel-bin/kRPC2 lib/ksp2/BepInEx/plugins/
-chmod 0664 lib/ksp2/BepInEx/plugins/kRPC2/*
+
+mkdir -p lib/ksp2/BepInEx/plugins/kRPC2
+cp -r bazel-bin/kRPC2/* lib/ksp2/BepInEx/plugins/kRPC2
+chmod -R 0664 lib/ksp2/BepInEx/plugins/kRPC2/*

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 buildifier -r ./
 dotnet format KRPC2.sln --exclude bazel-bin

--- a/tools/run-ksp2.sh
+++ b/tools/run-ksp2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install steam
 # Download KSP2
@@ -28,6 +28,6 @@ set -ev
 tools/install.sh
 
 echo "" > lib/ksp2/BepInEx/LogOutput.log
-steam steam://rungameid/954850 &
+steam steam://rungameid/954850 2> steam.log &
 # tail -f lib/ksp2/PDLauncher/Ksp2.log
 tail -f lib/ksp2/BepInEx/LogOutput.log


### PR DESCRIPTION
Whitespace changes are from your lint tool. Made some minor tool changes, I can put them in a separate PR if you really want.

Addressed the check list in #9 + eccentricity.
Looks like there might be multiple types of orbital classes in the future? (this would be consistent with what we know about Rusk and Rask: https://wiki.kerbalspaceprogram.com/wiki/Rusk), but for now- this is what is obviously used