### PR TITLE
Release archive packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
           rm ksp2-0.1.1.zip
       - name: build
         run: bazel build //:krpc2
+      - name: upload-krpc-artifact
+        uses: krpc/krpc-core/.github/actions/upload-artifact@main
+        with:
+          name: krpc
+          path: bazel-bin/krpc-*.zip
 
   build-krpc2-windows:
     runs-on: windows-latest

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,21 @@
-load("@rules_dotnet//dotnet:defs.bzl", "import_dll")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_dotnet//dotnet:defs.bzl", "import_dll")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//:config.bzl", "version")
+
+pkg_zip(
+    name = "krpc2",
+    srcs = [
+        "COPYING",
+        "LICENSE",
+        ":plugin_files",
+    ],
+    out = "krpc-%s.zip" % version,
+    package_dir = "BepInEx/plugins/kRPC2",
+)
 
 filegroup(
-    name = "krpc2",
+    name = "plugin_files",
     srcs = [
         ":copy_google_protobuf",
         ":copy_krpc2",

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Also check out the [contribution guide](https://github.com/krpc/krpc/blob/main/C
  * [Install Bazel](https://bazel.build/install/)
  * Create a symlink from `lib/ksp2` to where you have Kerbal Space Program 2 installed, so that you have `lib/ksp2/KSP_x64_Data/Managed/...`
  * Run `bazel build //:krpc2`
- * The resulting plugin files placed in the `bazel-bin/kRPC` directory
+ * The resulting plugin archive is placed in `bazel-bin/krpc-VERSION.zip`
 
 ## Building on Windows
 
@@ -69,7 +69,7 @@ Using Bazel:
    * If you get permissions errors related to symlinks when building you need to enable "Developer Mode".
  * Put a copy of KSP2 in lib/ksp2 (so you have `lib/ksp2/KSP_x64_Data/Managed/...`)
  * Run `bazel build //:krpc2`
- * The resulting plugin files are placed in the `bazel-bin/kRPC` directory
+ * The resulting plugin archive is placed in `bazel-bin/krpc-VERSION.zip`
 
 Using Visual Studio:
  * First you need to setup Bazel (see above for instructions). This is needed to generate a few files that are required to build the solution.


### PR DESCRIPTION
Fix #26 

`//:krpc2` target now builds the release archive. A copy is also uploaded to github actions build artifacts when ci workflow is run.