### PR TITLE
Adds Flight Controls (partially addresses #15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bazel-*
 
 # KSP2
 lib/ksp2
+*.log
 
 # Visual Studio
 .vs/

--- a/service/spacecenter/src/Control.cs
+++ b/service/spacecenter/src/Control.cs
@@ -1,0 +1,344 @@
+using System;
+using KSP.Sim.impl;
+using KSP.Sim.State;
+
+using KRPC.Service;
+using KRPC.Service.Attributes;
+using KRPC.Utils;
+
+// NOTE: This is basically just a reimplementation of KSP.Sim.impl/VesselVehicle with KRPC
+// bindings. Implemented for consistency with krpc1. Also note that SpaceWarp
+// VesselVehicleExtensions also provides something similar.
+namespace KRPC2.SpaceCenter
+{
+    /// <summary>
+    /// Used to manipulate the controls of a vessel. This includes adjusting the
+    /// throttle, enabling/disabling systems such as SAS and RCS, or altering the
+    /// direction in which the vessel is pointing.
+    /// Obtained by calling <see cref="Vessel.Control"/>.
+    /// </summary>
+    /// <remarks>
+    /// Control inputs (such as pitch, yaw and roll) are zeroed when all clients
+    /// that have set one or more of these inputs are no longer connected.
+    /// </remarks>
+    [KRPCClass(Service = "SpaceCenter2", GameScene = GameScene.Flight)]
+    public class Control : Equatable<Control>
+    {
+        readonly Guid vesselId;
+
+        internal Control(VesselComponent vessel)
+        {
+            // TODO: Don't hold on to vessel, object. Instead lookup from scope
+            // by ID. See the setter for this property.
+            InternalVessel = vessel;
+            vesselId = vessel.GlobalId;
+        }
+
+        /// <summary>
+        /// Returns true if the vesselIds are equal.
+        /// </summary>
+        public override bool Equals(Control other)
+        {
+            return !ReferenceEquals(other, null) && vesselId == other.vesselId;
+        }
+
+        /// <summary>
+        /// Hash code for the object.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return vesselId.GetHashCode();
+        }
+
+        /// <summary>
+        /// The KSP vessel object.
+        /// </summary>
+        public VesselComponent InternalVessel { get; private set; }
+
+        private void AtomicSet(FlightCtrlStateIncremental flightControlUpdate)
+        {
+            InternalVessel.ApplyFlightCtrlState(flightControlUpdate);
+        }
+
+        /// <summary>
+        /// The state of the throttle. A value between 0 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float Throttle
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.mainThrottle;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    mainThrottle = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the roll control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float Roll
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.roll;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    roll = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the yaw control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float Yaw
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.yaw;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    yaw = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the pitch control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float Pitch
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.pitch;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    pitch = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the roll trim control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float RollTrim
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.rollTrim;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    rollTrim = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the yaw trim control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float YawTrim
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.yawTrim;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    yawTrim = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the pitch trim control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float PitchTrim
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.pitchTrim;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    pitchTrim = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the wheel steer control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float WheelSteer
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.wheelSteer;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    wheelSteer = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the wheel steer trim control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float WheelSteerTrim
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.wheelSteerTrim;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    wheelSteerTrim = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the wheel throttle control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float WheelThrottle
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.wheelThrottle;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    wheelThrottle = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// The state of the wheel throttle trim control. A value between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float WheelThrottleTrim
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.wheelThrottleTrim;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    wheelThrottleTrim = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// Whether the gear up control is active.
+        /// </summary>
+        [KRPCProperty]
+        public bool Gear
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.gearUp;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    gearUp = value,
+                    gearDown = !value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// Whether the light control is active.
+        /// </summary>
+        [KRPCProperty]
+        public bool Lights
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.headlight;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    headlight = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+
+        /// <summary>
+        /// Whether the brakes control is active.
+        /// </summary>
+        [KRPCProperty]
+        public bool Brakes
+        {
+            get
+            {
+                return InternalVessel.flightCtrlState.brakes;
+            }
+            set
+            {
+                var incremental = new FlightCtrlStateIncremental()
+                {
+                    brakes = value
+                };
+                AtomicSet(incremental);
+            }
+        }
+    }
+}

--- a/service/spacecenter/src/Control.cs
+++ b/service/spacecenter/src/Control.cs
@@ -18,8 +18,8 @@ namespace KRPC2.SpaceCenter
     /// Obtained by calling <see cref="Vessel.Control"/>.
     /// </summary>
     /// <remarks>
-    /// Control inputs (such as pitch, yaw and roll) are zeroed when all clients
-    /// that have set one or more of these inputs are no longer connected.
+    /// Control inputs (such as pitch, yaw and roll) are instantaneous (the same
+    /// as tapping a button)
     /// </remarks>
     [KRPCClass(Service = "SpaceCenter2", GameScene = GameScene.Flight)]
     public class Control : Equatable<Control>
@@ -201,7 +201,7 @@ namespace KRPC2.SpaceCenter
         }
 
         /// <summary>
-        /// The state of the wheel steer control. A value between -1 and 1.
+        /// The state of the wheel steer control for rovers. A value between -1 and 1.
         /// </summary>
         [KRPCProperty]
         public float WheelSteer
@@ -221,7 +221,7 @@ namespace KRPC2.SpaceCenter
         }
 
         /// <summary>
-        /// The state of the wheel steer trim control. A value between -1 and 1.
+        /// The state of the wheel steer trim control for rovers. A value between -1 and 1.
         /// </summary>
         [KRPCProperty]
         public float WheelSteerTrim
@@ -241,7 +241,7 @@ namespace KRPC2.SpaceCenter
         }
 
         /// <summary>
-        /// The state of the wheel throttle control. A value between -1 and 1.
+        /// The state of the wheel throttle control for rovers. A value between -1 and 1.
         /// </summary>
         [KRPCProperty]
         public float WheelThrottle
@@ -261,7 +261,7 @@ namespace KRPC2.SpaceCenter
         }
 
         /// <summary>
-        /// The state of the wheel throttle trim control. A value between -1 and 1.
+        /// The state of the wheel throttle trim control for rovers. A value between -1 and 1.
         /// </summary>
         [KRPCProperty]
         public float WheelThrottleTrim

--- a/service/spacecenter/src/Control.cs
+++ b/service/spacecenter/src/Control.cs
@@ -81,8 +81,14 @@ namespace KRPC2.SpaceCenter
         }
 
         /// <summary>
-        /// The state of the roll control. A value between -1 and 1.
+        /// Instantaneous change to the roll control, and current roll state. A value between -1 and 1.
         /// </summary>
+        /// <remarks>
+        /// Reading this value provides the instantaneous roll control value.
+        /// Setting this value is the same as tapping q/e in stock KSP2.
+        /// The roll experienced by the vehicle will be RollTrim + Roll. KSP
+        /// will internally clamp this value between -1 and 1.
+        /// </remarks>
         [KRPCProperty]
         public float Roll
         {
@@ -101,8 +107,14 @@ namespace KRPC2.SpaceCenter
         }
 
         /// <summary>
-        /// The state of the yaw control. A value between -1 and 1.
+        /// Instantaneous change to the yaw control, and current yaw state. A value between -1 and 1.
         /// </summary>
+        /// <remarks>
+        /// Reading this value provides the instantaneous yaw control value.
+        /// Setting this value is the same as tapping a/d in stock KSP2.
+        /// The yaw experienced by the vehicle will be YawTrim + Yaw. KSP
+        /// will internally clamp this value between -1 and 1.
+        /// </remarks>
         [KRPCProperty]
         public float Yaw
         {
@@ -121,8 +133,14 @@ namespace KRPC2.SpaceCenter
         }
 
         /// <summary>
-        /// The state of the pitch control. A value between -1 and 1.
+        /// Instantaneous change to the pitch control, and current pitch state. A value between -1 and 1.
         /// </summary>
+        /// <remarks>
+        /// Reading this value provides the instantaneous pitch control value.
+        /// Setting this value is the same as tapping w/s in stock KSP2.
+        /// The pitch experienced by the vehicle will be PitchTrim + Pitch. KSP
+        /// will internally clamp this value between -1 and 1.
+        /// </remarks>
         [KRPCProperty]
         public float Pitch
         {
@@ -143,6 +161,10 @@ namespace KRPC2.SpaceCenter
         /// <summary>
         /// The state of the roll trim control. A value between -1 and 1.
         /// </summary>
+        /// <remarks>
+        /// This will set the roll control to have this value as a baseline.
+        /// For an instantaneous roll change, see <see cref="Roll"/>.
+        /// </remarks>
         [KRPCProperty]
         public float RollTrim
         {
@@ -163,6 +185,10 @@ namespace KRPC2.SpaceCenter
         /// <summary>
         /// The state of the yaw trim control. A value between -1 and 1.
         /// </summary>
+        /// <remarks>
+        /// This will set the yaw control to have this value as a baseline.
+        /// For an instantaneous yaw change, see <see cref="Yaw"/>.
+        /// </remarks>
         [KRPCProperty]
         public float YawTrim
         {
@@ -183,6 +209,10 @@ namespace KRPC2.SpaceCenter
         /// <summary>
         /// The state of the pitch trim control. A value between -1 and 1.
         /// </summary>
+        /// <remarks>
+        /// This will set the pitch control to have this value as a baseline.
+        /// For an instantaneous pitch change, see <see cref="Pitch"/>.
+        /// </remarks>
         [KRPCProperty]
         public float PitchTrim
         {
@@ -195,147 +225,6 @@ namespace KRPC2.SpaceCenter
                 var incremental = new FlightCtrlStateIncremental()
                 {
                     pitchTrim = value
-                };
-                AtomicSet(incremental);
-            }
-        }
-
-        /// <summary>
-        /// The state of the wheel steer control for rovers. A value between -1 and 1.
-        /// </summary>
-        [KRPCProperty]
-        public float WheelSteer
-        {
-            get
-            {
-                return InternalVessel.flightCtrlState.wheelSteer;
-            }
-            set
-            {
-                var incremental = new FlightCtrlStateIncremental()
-                {
-                    wheelSteer = value
-                };
-                AtomicSet(incremental);
-            }
-        }
-
-        /// <summary>
-        /// The state of the wheel steer trim control for rovers. A value between -1 and 1.
-        /// </summary>
-        [KRPCProperty]
-        public float WheelSteerTrim
-        {
-            get
-            {
-                return InternalVessel.flightCtrlState.wheelSteerTrim;
-            }
-            set
-            {
-                var incremental = new FlightCtrlStateIncremental()
-                {
-                    wheelSteerTrim = value
-                };
-                AtomicSet(incremental);
-            }
-        }
-
-        /// <summary>
-        /// The state of the wheel throttle control for rovers. A value between -1 and 1.
-        /// </summary>
-        [KRPCProperty]
-        public float WheelThrottle
-        {
-            get
-            {
-                return InternalVessel.flightCtrlState.wheelThrottle;
-            }
-            set
-            {
-                var incremental = new FlightCtrlStateIncremental()
-                {
-                    wheelThrottle = value
-                };
-                AtomicSet(incremental);
-            }
-        }
-
-        /// <summary>
-        /// The state of the wheel throttle trim control for rovers. A value between -1 and 1.
-        /// </summary>
-        [KRPCProperty]
-        public float WheelThrottleTrim
-        {
-            get
-            {
-                return InternalVessel.flightCtrlState.wheelThrottleTrim;
-            }
-            set
-            {
-                var incremental = new FlightCtrlStateIncremental()
-                {
-                    wheelThrottleTrim = value
-                };
-                AtomicSet(incremental);
-            }
-        }
-
-        /// <summary>
-        /// Whether the gear up control is active.
-        /// </summary>
-        [KRPCProperty]
-        public bool Gear
-        {
-            get
-            {
-                return InternalVessel.flightCtrlState.gearUp;
-            }
-            set
-            {
-                var incremental = new FlightCtrlStateIncremental()
-                {
-                    gearUp = value,
-                    gearDown = !value
-                };
-                AtomicSet(incremental);
-            }
-        }
-
-        /// <summary>
-        /// Whether the light control is active.
-        /// </summary>
-        [KRPCProperty]
-        public bool Lights
-        {
-            get
-            {
-                return InternalVessel.flightCtrlState.headlight;
-            }
-            set
-            {
-                var incremental = new FlightCtrlStateIncremental()
-                {
-                    headlight = value
-                };
-                AtomicSet(incremental);
-            }
-        }
-
-        /// <summary>
-        /// Whether the brakes control is active.
-        /// </summary>
-        [KRPCProperty]
-        public bool Brakes
-        {
-            get
-            {
-                return InternalVessel.flightCtrlState.brakes;
-            }
-            set
-            {
-                var incremental = new FlightCtrlStateIncremental()
-                {
-                    brakes = value
                 };
                 AtomicSet(incremental);
             }

--- a/service/spacecenter/src/Vessel.cs
+++ b/service/spacecenter/src/Vessel.cs
@@ -1,5 +1,6 @@
 using System;
 using KSP.Sim.impl;
+using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
 
@@ -58,6 +59,17 @@ namespace KRPC2.SpaceCenter
         public Orbit Orbit
         {
             get { return new Orbit(InternalVessel); }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Control"/> object that can be used to manipulate
+        /// the vessel's control inputs. For example, its pitch/yaw/roll controls,
+        /// RCS and thrust.
+        /// </summary>
+        [KRPCProperty(GameScene = GameScene.Flight)]
+        public Control Control
+        {
+            get { return new Control(InternalVessel); }
         }
     }
 }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -ev
-bazel build --verbose_failures //:krpc2
+bazel build --verbose_failures //:plugin_files
 rm -rf lib/ksp2/BepInEx/plugins/kRPC2
 rm -f lib/ksp2/BepInEx/config/krpc2.cfg
 


### PR DESCRIPTION
Copilot doing a lot of the heavy lifting!

Would be nice to have a testing scaffold (see #29), but for now ensuring the end points work by hand

Notably, `x_trim` are new but exposed in the API. I thought I would put them in here. Relatively easy to add position changes as well.

Added endpoints:
 - throttle
 - pitch [trim]
 - yaw [trim]
 - roll [trim]
 - ~wheelsteer [trim]~
 - ~wheelthrottle [trim]~
 - ~lights~
 - ~break~
 - ~gear~

Sample script:
```python
import krpc
import matplotlib.pyplot as plt
from time import sleep

print(krpc.__version__)
conn = krpc.connect()
vessel = conn.space_center2.active_vessel
print("eccentricity", vessel.orbit.eccentricity)
print("major", vessel.orbit.semi_major_axis)
print("initial apoapsis", vessel.orbit.apoapsis)
print("initial periapsis", vessel.orbit.periapsis)

apoapsis = [] 
periapsis = [] 
print("GO!")

t = list(range(100))

for s in t:
  apoapsis.append(vessel.orbit.apoapsis)
  periapsis.append(vessel.orbit.periapsis)

  # Auto Burn in cycles
  if s % 10 == 0:
    if (s // 10) % 2 == 0:
      vessel.control.throttle = 1
      vessel.control.pitch = -1
    else:
      vessel.control.throttle = 0
      vessel.control.pitch = 1

  sleep(0.5)

plt.plot(t, apoapsis)
plt.plot(t, periapsis)
plt.savefig("burn")
```

and result.

Setting pitch is the same as tapping W. Doing pitch_trim is the same as holding W. I don't remember the behavior of the original API

![image](https://user-images.githubusercontent.com/2689338/227813848-d6d4ddac-684d-4946-a083-318e2283be04.png)
