### PR TITLE
Added issue templates

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,38 @@
+name: "🪲 Bug Report"
+description: Tell us about the bug so we can improve kRPC2!
+labels: ['bug', 'needs-triage']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide a clear and concise description of what the bug is.
+        If applicable, include screenshots or log output to help explain your problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can someone else reproduce it?
+      description: |
+        Please describe how to reproduce the issue.
+        For example, a kRPC script that exhibits the bug or a save file.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: What is your environment?
+      description: |
+        For example, what version of the mod are you using? What version of the game are you using?
+        Do you have any other mods installed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?

--- a/.github/workflows/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,17 @@
+name: "🚀 Feature Request"
+description: Suggest a new feature for kRPC2!
+labels: ['enhancement', 'needs-triage']
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reasoning
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true


### PR DESCRIPTION
**Summary:**

Added issue templates to preserve consistency across krpc org. 
Since doc structure is unknown, docs-issue template left out. 

**Changes:**
- Added ISSUE_TEMPLATE/01-bug-report.yml, same as krpc.
- Added ISSUE_TEMPLATE/02-feature-request.yml, same as krpc.
- Holding off on docs-issue template.