### PR TITLE
Update CI workflow to cache bazel dependencies on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - name: fetch
+        uses: krpc/krpc-core/.github/actions/bazel-fetch@main
       - name: libs
         shell: pwsh
         run: |
@@ -95,6 +97,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - name: fetch
+        uses: krpc/krpc-core/.github/actions/bazel-fetch@main
       - name: libs
         shell: pwsh
         run: |


### PR DESCRIPTION
Fixes #36 